### PR TITLE
Fix logging bug in download service

### DIFF
--- a/app/src/main/java/com/github/libretube/services/DownloadService.kt
+++ b/app/src/main/java/com/github/libretube/services/DownloadService.kt
@@ -348,7 +348,7 @@ class DownloadService : LifecycleService() {
 
                 return@withContext handleResponse(item, response)
             } catch (e: IOException) {
-                Log.e(this::javaClass.name, e.printStackTrace().toString())
+                Log.e(DownloadService::class.java.name, e.stackTraceToString())
 
                 val message = getString(R.string.downloadfailed)
                 _downloadFlow.emit(item.id to DownloadStatus.Error(message))


### PR DESCRIPTION
## Summary
- fix incorrect use of `javaClass` and `printStackTrace` when logging IO errors in `DownloadService`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fbaa136c8323ae5dd5461222166c